### PR TITLE
Exclude image format from file search

### DIFF
--- a/app.py
+++ b/app.py
@@ -257,9 +257,6 @@ def load_chat_screen(assistant_id, assistant_title):
             type=[
                 "txt",
                 "pdf",
-                "png",
-                "jpg",
-                "jpeg",
                 "csv",
                 "json",
                 "geojson",


### PR DESCRIPTION
Exclude image format like png, jpg and jpeg because OpenAI Assistant file search tool does not support image format so far. This change will reduce error when uoading images.