### PR TITLE
Fix: Missing README.md Error During Docker-Compose Installation (ENV FILES NOT CHANGED)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && \
     pip3 install --upgrade pip && \
     pip3 install poetry && \
     poetry config virtualenvs.create false && \
-    poetry install
+    poetry install --no-root
 
 EXPOSE 8501
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,6 @@ services:
     build:
       context: ./
       dockerfile: ./Dockerfile
-    environment:
-      - "OPENAI_API_KEY=${OPENAI_API_KEY}"
-      - "APP_ENABLED_FILE_UPLOAD_MESSAGE=${APP_ENABLED_FILE_UPLOAD_MESSAGE}"
-      - "AUTHENTICATION_REQUIRED=${AUTHENTICATION_REQUIRED}"
-      - "ASSISTANT_ID=${ASSISTANT_ID}"
-      - "ASSISTANT_TITLE=${ASSISTANT_TITLE}"
-      - "OPENAI_ASSISTANTS=${OPENAI_ASSISTANTS}"
+    env_file: .env
+    ports:
+      - "8501:8501"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     build:
       context: ./
       dockerfile: ./Dockerfile
-    env_file: .env
-    ports:
-      - "8501:8501"
+    environment:
+      - "OPENAI_API_KEY=${OPENAI_API_KEY}"
+      - "APP_ENABLED_FILE_UPLOAD_MESSAGE=${APP_ENABLED_FILE_UPLOAD_MESSAGE}"
+      - "AUTHENTICATION_REQUIRED=${AUTHENTICATION_REQUIRED}"
+      - "ASSISTANT_ID=${ASSISTANT_ID}"
+      - "ASSISTANT_TITLE=${ASSISTANT_TITLE}"
+      - "OPENAI_ASSISTANTS=${OPENAI_ASSISTANTS}"


### PR DESCRIPTION
### Fix: Missing README.md Error During Docker-Compose Installation
**Problem**
When installing using Docker-Compose, the following error occurs:

```
156.3 Installing the current project: gpt-assistants-api-ui (0.1.0)
156.3 Error: The current project could not be installed: Readme path `/app/README.md` does not exist.
156.3 If you do not want to install the current project use --no-root.
156.3 If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
156.3 If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file.
```

**Cause**
In the Dockerfile, only pyproject.toml and poetry.lock are copied:
```
COPY pyproject.toml poetry.lock ./
```
Since README.md is referenced in pyproject.toml but is not included in the image, the installation fails.

**Solution**
This fix is to **disable the root package installation** by adding `--no-root` to the `poetry install` command, preventing the error.

Steps to Reproduce

1. Clear old containers and images related to this project.
2. Start up the Docker-Compose file.