### PR TITLE
Fix Streamlit Cloud setup, sync docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
     ```bash
     # OpenAI settings
     OPENAI_API_KEY="sk-xxx"
-    APP_ENABLED_FILE_UPLOAD_MESSAGE="Upload a file" # Leave empty to disable
+    ENABLED_FILE_UPLOAD_MESSAGE="Upload a file" # Leave empty to disable
 
     AUTHENTICATION_REQUIRED="False" # Must change to True if you require authentication
 
@@ -93,7 +93,7 @@ To use authentication with Streamlit Cloud, please use this TOML format:
 # Environment variables
 # OpenAI settings
 OPENAI_API_KEY="sk-xxx"
-APP_ENABLED_FILE_UPLOAD_MESSAGE="Upload a file" # Leave empty to disable
+ENABLED_FILE_UPLOAD_MESSAGE="Upload a file" # Leave empty to disable
 
 AUTHENTICATION_REQUIRED="False" # Must change to True if you require authentication
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
     # When using multiple assistants, set the following.
     OPENAI_ASSISTANTS='[{"id": "asst_xxx", "title": "Assistants XXX UI"}, {"id": "asst_yyy", "title": "Assistants YYY UI"}]'
    
-   # App setting
+   # App settings
     ENABLED_FILE_UPLOAD_MESSAGE="Upload a file" # Leave empty to disable
     AUTHENTICATION_REQUIRED="False" # Must change to True if you require authentication
     ```
@@ -102,7 +102,7 @@ ASSISTANT_TITLE="Assistants API UI" # This is for the single agent title
 # When using multiple assistants, set the following.
 OPENAI_ASSISTANTS='[{"id": "asst_xxx", "title": "Assistants XXX UI"}, {"id": "asst_yyy", "title": "Assistants YYY UI"}]'
 
-# App setting
+# App settings
 ENABLED_FILE_UPLOAD_MESSAGE="Upload a file" # Leave empty to disable
 AUTHENTICATION_REQUIRED="False" # Must change to True if you require authentication
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@
     ```bash
     # OpenAI settings
     OPENAI_API_KEY="sk-xxx"
-    ENABLED_FILE_UPLOAD_MESSAGE="Upload a file" # Leave empty to disable
-
-    AUTHENTICATION_REQUIRED="False" # Must change to True if you require authentication
 
     # When using only one assistant, set the following, unset the OPENAI_ASSISTANTS variable.
     ASSISTANT_ID="asst_xxx"
@@ -41,6 +38,10 @@
 
     # When using multiple assistants, set the following.
     OPENAI_ASSISTANTS='[{"id": "asst_xxx", "title": "Assistants XXX UI"}, {"id": "asst_yyy", "title": "Assistants YYY UI"}]'
+   
+   # App setting
+    ENABLED_FILE_UPLOAD_MESSAGE="Upload a file" # Leave empty to disable
+    AUTHENTICATION_REQUIRED="False" # Must change to True if you require authentication
     ```
     If you use azure instead, set `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_KEY`
 
@@ -93,9 +94,6 @@ To use authentication with Streamlit Cloud, please use this TOML format:
 # Environment variables
 # OpenAI settings
 OPENAI_API_KEY="sk-xxx"
-ENABLED_FILE_UPLOAD_MESSAGE="Upload a file" # Leave empty to disable
-
-AUTHENTICATION_REQUIRED="False" # Must change to True if you require authentication
 
 # When using only one assistant, set the following, unset the OPENAI_ASSISTANTS variable.
 ASSISTANT_ID="asst_xxx"
@@ -103,6 +101,10 @@ ASSISTANT_TITLE="Assistants API UI" # This is for the single agent title
 
 # When using multiple assistants, set the following.
 OPENAI_ASSISTANTS='[{"id": "asst_xxx", "title": "Assistants XXX UI"}, {"id": "asst_yyy", "title": "Assistants YYY UI"}]'
+
+# App setting
+ENABLED_FILE_UPLOAD_MESSAGE="Upload a file" # Leave empty to disable
+AUTHENTICATION_REQUIRED="False" # Must change to True if you require authentication
 
 # Authentication secrets
 [credentials]

--- a/gpt_assistants_api_ui/README.md
+++ b/gpt_assistants_api_ui/README.md
@@ -1,0 +1,9 @@
+This module is **required** to run the app in Streamlit Cloud.
+
+Otherwise, you will get the following error during installation:
+
+```
+...
+Installing the current project: gpt-assistants-api-ui (0.1.0)
+Error: The current project could not be installed: No file/folder found for package gpt-assistants-api-ui
+```


### PR DESCRIPTION
Hi @ryo-ma,

Here are small fixes:
1. Streamlit Cloud requires "gpt_assistants_api_ui" module to be present
2. "ENABLED_FILE_UPLOAD_MESSAGE" was prefixed by "APP_" in README, but left untouched in code. So, I recovered its name in docs